### PR TITLE
Add isort file paths

### DIFF
--- a/{{ cookiecutter.project_name }}/Makefile
+++ b/{{ cookiecutter.project_name }}/Makefile
@@ -109,7 +109,7 @@ check-safety:
 check-style:
 	$(BLACK_COMMAND_FLAG)poetry run black --config pyproject.toml --diff --check ./
 	$(DARGLINT_COMMAND_FLAG)poetry run darglint -v 2 **/*.py
-	$(ISORT_COMMAND_FLAG)poetry run isort --settings-path pyproject.toml --check-only
+	$(ISORT_COMMAND_FLAG)poetry run isort --settings-path pyproject.toml --check-only **/*.py
 	$(MYPY_COMMAND_FLAG)poetry run mypy --config-file setup.cfg {{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }} tests/**/*.py
 
 .PHONY: codestyle


### PR DESCRIPTION
An empty file path will lead to `Error: arguments passed in without any paths or content.` in Actions

## Description

style-check is throwing an error with isort (python 3.8 isort 5.5.4)
```
poetry run black --config pyproject.toml --diff --check ./
All done! ✨ 🍰 ✨
5 files would be left unchanged.
poetry run darglint -v 2 **/*.py
poetry run isort --settings-path pyproject.toml --check-only


                 _                 _
                (_) ___  ___  _ __| |_
                | |/ _/ / _ \/ '__  _/
                | |\__ \/\_\/| |  | |_
Error: arguments passed in without any paths or content.
                |_|\___/\___/\_/   \_/

      isort your imports, so you don't have to.

                    VERSION 5.5.4


Nothing to do: no files or paths have have been passed in!

Try one of the following:

    `isort .` - sort all Python files, starting from the current directory, recursively.
    `isort . --interactive` - Do the same, but ask before making any changes.
    `isort . --check --diff` - Check to see if imports are correctly sorted within this project.
    `isort --help` - In-depth information about isort's available command-line options.

Visit https://pycqa.github.io/isort/ for complete information about how to use isort.

make: *** [check-style] Error 1
Makefile:110: recipe for target 'check-style' failed
Error: Process completed with exit code 2.
```

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/TezRomacH/python-package-template/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/TezRomacH/python-package-template/blob/master/CONTRIBUTING.md) guide.
- [] I've updated the code style using `make codestyle`.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in `Google` format for all the methods and classes that I used.
