### PR TITLE
Fix wrong parentheses in Makefile strict tests

### DIFF
--- a/{{ cookiecutter.project_name }}/Makefile
+++ b/{{ cookiecutter.project_name }}/Makefile
@@ -43,7 +43,7 @@ endif
 
 ifeq ($(SAFETY_STRICT), 1)
 	SAFETY_COMMAND_FLAG =
-else ifeq ($SAFETY_STRICT), 0)
+else ifeq ($(SAFETY_STRICT), 0)
 	SAFETY_COMMAND_FLAG = -
 endif
 
@@ -67,7 +67,7 @@ endif
 
 ifeq ($(DARGLINT_STRICT), 1)
 	DARGLINT_COMMAND_FLAG =
-else ifeq (DARGLINT_STRICT), 0)
+else ifeq ($(DARGLINT_STRICT), 0)
 	DARGLINT_COMMAND_FLAG = -
 endif
 


### PR DESCRIPTION
A few variables were not correctly escaped and caused incorrect syntax in some `else ifeq` statements

## Description

*none*

## Related Issue

*none*

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/TezRomacH/python-package-template/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/TezRomacH/python-package-template/blob/master/CONTRIBUTING.md) guide.
- [ ] I've updated the code style using `make codestyle`.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in `Google` format for all the methods and classes that I used.
