### PR TITLE
Replace poetry with poetry_core in  build-system

### DIFF
--- a/{{ cookiecutter.project_name }}/pyproject.toml
+++ b/{{ cookiecutter.project_name }}/pyproject.toml
@@ -1,8 +1,8 @@
 # Poetry pyproject.toml: https://python-poetry.org/docs/pyproject/
 
 [build-system]
-requires = ["poetry>=1.0"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry_core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "{{ cookiecutter.project_name }}"


### PR DESCRIPTION
## Description

Replace full-featured poetry package with lightweight poetry_core in build-system requirement according to https://python-poetry.org/docs/pyproject/#poetry-and-pep-517 (last callout)

## Type of Change

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist
- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/TezRomacH/python-package-template/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/TezRomacH/python-package-template/blob/master/CONTRIBUTING.md) guide.
- [x] I've updated the code style using `make codestyle`.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in `Google` format for all the methods and classes that I used.
