### PR TITLE
Fix details rendering for code security section

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,9 @@ make check-codestyle
 
 > Note: `check-codestyle` uses `isort`, `black` and `darglint` library
 
+</p>
+</details>
+
 <details>
 <summary>4. Code security</summary>
 <p>
@@ -226,9 +229,6 @@ This command launches `Poetry` integrity checks as well as identifies security i
 ```bash
 make check-safety
 ```
-
-</p>
-</details>
 
 </p>
 </details>


### PR DESCRIPTION
## Description

Fix Markdown rendering of "code security" section in README

Before this change, note the missing `4.`:

<img width="452" alt="Screen Shot 2021-08-12 at 8 33 28 AM" src="https://user-images.githubusercontent.com/10340167/129197368-d3eaf512-6682-4832-9a8a-0dece8078011.png">


## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/TezRomacH/python-package-template/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/TezRomacH/python-package-template/blob/master/CONTRIBUTING.md) guide.
- [ ] I've updated the code style using `make codestyle`.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in `Google` format for all the methods and classes that I used.
