### PR TITLE
add publish to pypi github actions and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,12 +144,23 @@ poetry run <project_name> --name Roman
 
 ### Building and releasing your package
 
-Building a new version of the application contains steps:
+If you don't want to release your project to PyPI, simply remove `.github/workflows/publish-to-pypi.yml`.
+
+To release your project, do the following steps:
+
+One time setup:
+- Sign up to the [test PyPI](https://test.pypi.org/account/register/) and [production PyPI](https://pypi.org/account/register/). Registration is free.
+- Create API tokens for both the test and production account. Tokens can be created under [Account Settings](https://test.pypi.org/manage/account/).
+- Store the tokes in your GitHub project: Settings -> Secrets -> Actions 
+- Name the secrets `TEST_PYPI_PASSWORD` and `PROD_PYPI_PASSWORD` respectively.
+- Once you release the first version of your application (see below), you can create API tokes with a narrow scope of just this project and replace the GitHub tokens. 
+
+Releasing a new version of the application contains these steps:
 
 - Bump the version of your package `poetry version <version>`. You can pass the new version explicitly, or a rule such as `major`, `minor`, or `patch`. For more details, refer to the [Semantic Versions](https://semver.org/) standard.
-- Make a commit to `GitHub`.
-- Create a `GitHub release`.
-- And... publish 🙂 `poetry publish --build`
+- Make a commit to any feature branch of `GitHub`. The `build-and-publish-test` job would publish your version to the [test PyPI](https://test.pypi.org/).
+- Create a tag, by creating a `GitHub release`. The `build-and-publish-production` job would publish your version to the [production PyPI](https://pypi.org/).
+
 
 ### Makefile usage
 
@@ -394,7 +405,6 @@ This template will continue to develop and follow the bleeding edge new tools an
 Here is a list of things that have yet to be implemented:
 
 - Tests coverage reporting ([`Codecov`](https://github.com/marketplace/codecov) ?).
-- Auto uploading your package to [`PyPI`](https://pypi.org/) when new GitHub release is created.
 - Automatic creation and deployment of documentation to GitHub pages. I look at [`MkDocs`](https://www.mkdocs.org/) with [Material Design theme](https://github.com/squidfunk/mkdocs-material) and [`mkdocstrings`](https://github.com/pawamoy/mkdocstrings).
 - Code metrics with [`Radon`](https://github.com/rubik/radon).
 - Docstring coverage with [`interrogate`](https://github.com/econchick/interrogate)

--- a/{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}/.github/workflows/publish-to-pypi.yml
+++ b/{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}/.github/workflows/publish-to-pypi.yml
@@ -1,0 +1,87 @@
+{% raw %}name: Publish python distribution to PyPI
+on: push
+
+jobs:
+  build-and-publish-test:
+    name: Build and publish python distribution to test PyPI
+    runs-on: ubuntu-18.04
+    if: "!(startsWith(github.event.ref, 'refs/tags') || github.ref == 'refs/heads/main')"
+    continue-on-error: true
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v3
+        with:
+          python-version: 3.8
+      - name: Setup pip
+        run: python -m pip install pip==21.0.1
+      - name: Build and publish to pypi
+        uses: JRubics/poetry-publish@v1.10
+        with:
+          python_version: '3.8.10'
+          poetry_version: "==1.1.4"
+          repository_name: '{% endraw %}{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}{% raw %}'
+          repository_url: 'https://test.pypi.org/legacy/'
+          pypi_token: ${{ secrets.test_pypi_password }}
+        continue-on-error: true
+      - name: Sleep to allow pypi index to update with the new version
+        run: sleep 5m
+      - name: Install poetry
+        run: make poetry-download
+      - name: Cleanup
+        run: |
+          rm -r {% endraw %}{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}{% raw %}
+          pip uninstall {% endraw %}{{ cookiecutter.project_name }}{% raw %}
+      - name: Perform System tests
+        run: |
+          poetry export --dev --without-hashes -f requirements.txt --output test-requirements.txt
+          pip install -r test-requirements.txt
+          pip install -i https://test.pypi.org/simple/ {% endraw %}{{ cookiecutter.project_name }}{% raw %}
+          python -m pytest -vvv
+          export INSTALLED=`pip freeze | grep {% endraw %}{{ cookiecutter.project_name }}{% raw %}`
+          echo "installed is: $INSTALLED, and we care about ${INSTALLED:21}"
+          export EXPECTED=`poetry version --short`
+          echo "expected is: $EXPECTED"
+          if [ "${INSTALLED:21}" != "$EXPECTED" ]; then exit 1; fi
+
+  build-and-publish-production:
+    name: Build and publish python distribution to production PyPI
+    runs-on: ubuntu-18.04
+    if: startsWith(github.event.ref, 'refs/tags')
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v3
+        with:
+          python-version: 3.8
+      - name: Setup pip
+        run: python -m pip install pip==21.0.1
+      - name: Build and publish to pypi
+        uses: JRubics/poetry-publish@v1.10
+        with:
+          python_version: '3.8.10'
+          poetry_version: "==1.1.4"
+          repository_name: '{% endraw %}{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}{% raw %}'
+          pypi_token: ${{ secrets.prod_pypi_password }}
+        continue-on-error: true
+      - name: Sleep to allow pypi index to update with the new version
+        run: sleep 5m
+      - name: Install poetry
+        run: make poetry-download
+      - name: Cleanup
+        run: |
+          rm -r {% endraw %}{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}{% raw %}
+          pip uninstall {% endraw %}{{ cookiecutter.project_name }}{% raw %}
+      - name: Perform System tests
+        run: |
+          poetry export --dev --without-hashes -f requirements.txt --output test-requirements.txt
+          pip install -r test-requirements.txt
+          pip install {% endraw %}{{ cookiecutter.project_name }}{% raw %}
+          python -m pytest -vvv -k
+          export INSTALLED=`pip freeze | grep {% endraw %}{{ cookiecutter.project_name }}{% raw %}`
+          echo "installed is: $INSTALLED, and we care about ${INSTALLED:21}"
+          export EXPECTED=`poetry version --short`
+          echo "expected is: $EXPECTED"
+          if [ "${INSTALLED:21}" != "$EXPECTED" ]; then exit 1; fi{% endraw %}

--- a/{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}/README.md
+++ b/{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}/README.md
@@ -81,12 +81,22 @@ etc
 
 ### Building and releasing your package
 
-Building a new version of the application contains steps:
+If you don't want to release your project to PyPI, simply remove `.github/workflows/publish-to-pypi.yml`.
+
+To release your project, do the following steps:
+
+One time setup:
+- Sign up to the [test PyPI](https://test.pypi.org/account/register/) and [production PyPI](https://pypi.org/account/register/). Registration is free.
+- Create API tokens for both the test and production account. Tokens can be created under [Account Settings](https://test.pypi.org/manage/account/). Use Entire account scope at first. 
+- Store the tokes in your GitHub project: [Settings -> Secrets -> Actions](https://github.com/{{ cookiecutter.github_name }}/{{ cookiecutter.project_name }}/settings/secrets/actions)
+- Name the secrets `TEST_PYPI_PASSWORD` and `PROD_PYPI_PASSWORD` respectively.
+- Once you release the first version of your application (see below), you can create API tokes with a narrow scope of just this project and replace the GitHub tokens. 
+
+Releasing a new version of the application contains these steps:
 
 - Bump the version of your package `poetry version <version>`. You can pass the new version explicitly, or a rule such as `major`, `minor`, or `patch`. For more details, refer to the [Semantic Versions](https://semver.org/) standard.
-- Make a commit to `GitHub`.
-- Create a `GitHub release`.
-- And... publish 🙂 `poetry publish --build`
+- Make a commit to any feature branch of `GitHub`. The `build-and-publish-test` job would publish your version to the [test PyPI](https://test.pypi.org/).
+- Create a tag, by creating a `GitHub release`. The `build-and-publish-production` job would publish your version to the [production PyPI](https://pypi.org/).
 
 ## 🎯 What's next
 


### PR DESCRIPTION
## Description

Added publish to pypi github actions and documentation.

The action was tested successfully on two of my projects which were created using this template:

https://github.com/pksol/pytest-fastapi-deps

https://github.com/pksol/pytest-mock-generator

I also updated the documentation to match the new functionality.

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/TezRomacH/python-package-template/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/TezRomacH/python-package-template/blob/master/CONTRIBUTING.md) guide.
- [x] I've updated the code style using `make codestyle`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in `Google` format for all the methods and classes that I used.
